### PR TITLE
Removed raising an event

### DIFF
--- a/test/w3c-ecma/test152.txml.scxml
+++ b/test/w3c-ecma/test152.txml.scxml
@@ -16,7 +16,6 @@ not being executed. --><scxml xmlns="http://www.w3.org/2005/07/scxml" xmlns:conf
         <foreach item="Var2" index="Var3" array="Var4">
           <assign location="Var1" expr="Var1 + 1"/>
           </foreach>
-        <raise event="foo"/>
         </onentry>
    <transition event="error.execution" target="s1"/>
    <transition event="*" target="fail"/> 


### PR DESCRIPTION
If we raise an event foo at s0, on s1 our event queue will not be
error.execution, thus test won’t pass.

**Check with**
Issue: https://github.com/jbeard4/SCION/issues/285
PR: https://github.com/jbeard4/SCION/pull/292
