### PR TITLE
Remove the outrunning exit

### DIFF
--- a/lib/test-client.js
+++ b/lib/test-client.js
@@ -209,7 +209,7 @@ function complete(cb){
         generate_console_report(testResults, done);
     }
 
-    cb();
+    cb(testsErrored + testsFailed);
 }
 
 function done(){
@@ -217,8 +217,7 @@ function done(){
   console.log("TEST RESULTS");
   console.log("\x1b[32mPassed: " + testsPassed + "\x1b[0m, \x1b[31mError: " + testsErrored + "\x1b[0m, \x1b[35mFailed: " + testsFailed + "\x1b[0m");
   
-  console.log('exit status',testsErrored + testsFailed);
-  process.exit(testsErrored + testsFailed);   
+  console.log('exit status',testsErrored + testsFailed);   
 }
 
 function generate_html_report (results, report_done) {


### PR DESCRIPTION
If we are using test-client as module there is no chance to run a callback function. I think the simplest way would be pass an error code as argument and call process.exit inside the callback function if need it.